### PR TITLE
[feature #268890] Fix JdbcTableInputStream large-file buffer handling and add tests

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -234,6 +234,12 @@
                 <version>2.18.0</version>
                 <scope>test</scope>
             </dependency>
+            <dependency>
+                <groupId>org.mockito</groupId>
+                <artifactId>mockito-core</artifactId>
+                <version>4.11.0</version>
+                <scope>test</scope>
+            </dependency>
 
             <dependency>
                 <groupId>com.seeburger.vfs2</groupId>

--- a/vfs2provider-jdbctable/pom.xml
+++ b/vfs2provider-jdbctable/pom.xml
@@ -55,6 +55,11 @@
             <scope>test</scope>
         </dependency>
         <dependency>
+            <groupId>org.mockito</groupId>
+            <artifactId>mockito-core</artifactId>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
             <groupId>com.googlecode.flyway</groupId>
             <artifactId>flyway-core</artifactId>
             <version>2.3.1</version>

--- a/vfs2provider-jdbctable/src/main/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStream.java
+++ b/vfs2provider-jdbctable/src/main/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStream.java
@@ -17,13 +17,11 @@ import com.seeburger.vfs2.provider.jdbctable.JdbcTableRowFile.DataDescription;
 
 
 /**
- * Input Stream backed by a JDBC blob.
- * <P>
- * WARNING: this currently only allows to read blobs up to 50 MB.
- * This is a TODO, it is intended to reopen the Blob every {@link #MAX_BUFFER_SIZE}
- * read bytes.
+ * Input Stream backed by a JDBC blob that transparently loads data in chunks of at most
+ * {@link #MAX_BUFFER_SIZE} bytes, supporting files of arbitrary size.
  *
  * @see JdbcTableRowFile#startReadData(int)
+ * @see JdbcTableRowFile#nextReadData(DataDescription, int)
  * @see JdbcTableRowFile#doGetInputStream()
  */
 public class JdbcTableInputStream extends InputStream
@@ -32,8 +30,21 @@ public class JdbcTableInputStream extends InputStream
 
     static final int MAX_BUFFER_SIZE = 50 * 1024 * 1024;
 
-    /** Keep state for re-requesting additional data. */
+    /**
+     * Abstracts next-chunk loading so the stream can be tested without a real database.
+     * Implementations must return a byte array of up to {@code maxLen} bytes read from
+     * the backing store starting at absolute file position {@code pos}.
+     */
+    interface ChunkLoader
+    {
+        byte[] load(long pos, int maxLen) throws IOException;
+    }
+
+    /** Keep state for re-requesting additional data (position, generation, total length). */
     final DataDescription dataDescription;
+
+    /** Loads the next chunk from the backing store when the current buffer is exhausted. */
+    private final ChunkLoader chunkLoader;
 
     /** position for mark/reset support. */
     long mark = 0;
@@ -48,33 +59,60 @@ public class JdbcTableInputStream extends InputStream
     protected JdbcTableInputStream(JdbcTableRowFile file) throws IOException
     {
         long fileSize = file.getContent().getSize();
-        int bufsize;
+        int bufsize = (fileSize > MAX_BUFFER_SIZE) ? MAX_BUFFER_SIZE : (int) fileSize;
 
-        if (fileSize > (long)MAX_BUFFER_SIZE)
-        {
-            bufsize = MAX_BUFFER_SIZE;
-            LOG.warn("JdbcTableInputStream on " + file  + " only supports " + MAX_BUFFER_SIZE + " bytes. (filesize=" + fileSize + ")");
-        }
-        else
-        {
-            bufsize = (int)fileSize;
-        }
-
-        // This is used to keep optimistic lockig state.
+        // This is used to keep optimistic locking state.
         dataDescription = file.startReadData(bufsize);
         buf = dataDescription.buffer;
         bufferPos = 0;
         bufferSize = buf.length;
+
+        if (LOG.isDebugEnabled() && fileSize > MAX_BUFFER_SIZE)
+        {
+            LOG.debug("JdbcTableInputStream on " + file + " will load " + fileSize
+                      + " bytes in chunks of " + MAX_BUFFER_SIZE);
+        }
+
+        this.chunkLoader = (pos, maxLen) -> {
+            dataDescription.pos = pos;
+            file.nextReadData(dataDescription, maxLen);
+            return dataDescription.buffer;
+        };
+    }
+
+    /**
+     * Loads the next chunk from the backing store into {@link #buf}.
+     * Updates {@code dataDescription.pos}, {@link #bufferPos}, and {@link #bufferSize}.
+     *
+     * @return {@code true} if at least one byte was loaded; {@code false} at EOF
+     * @throws IOException if the backing store signals an error or detects a content change
+     */
+    private boolean loadNextChunk() throws IOException
+    {
+        long nextPos = dataDescription.pos + bufferSize;
+        if (nextPos >= dataDescription.dataLength)
+        {
+            return false;
+        }
+        int maxLen = (int) Math.min(MAX_BUFFER_SIZE, dataDescription.dataLength - nextPos);
+        buf = chunkLoader.load(nextPos, maxLen);
+        dataDescription.pos = nextPos;
+        bufferPos = 0;
+        bufferSize = buf.length;
+        return bufferSize > 0;
     }
 
     /**
      * Reads the next byte of data from this input stream.
      */
-    public synchronized int read()
+    public synchronized int read() throws IOException
     {
         if (bufferPos >= bufferSize)
         {
-            return -1;
+            if (!loadNextChunk())
+            {
+                return -1;
+            }
         }
 
         return (buf[bufferPos++] & 0xff);
@@ -84,31 +122,27 @@ public class JdbcTableInputStream extends InputStream
      * Reads up to <code>len</code> bytes of data into an array of bytes
      * from this input stream.
      */
-    public synchronized int read(byte b[], int off, int len)
+    public synchronized int read(byte b[], int off, int len) throws IOException
     {
         if (off < 0 || len < 0 || len > b.length - off)
         {
             throw new IndexOutOfBoundsException();
         }
 
-        if (bufferPos >= bufferSize)
-        {
-            return -1;
-        }
-
-        int readBytes;
-        if (bufferPos + len > bufferSize)
-        {
-            readBytes = bufferSize - bufferPos;
-        } else {
-            readBytes = len;
-        }
-
-        if (readBytes <= 0) // == 0
+        if (len == 0)
         {
             return 0;
         }
 
+        if (bufferPos >= bufferSize)
+        {
+            if (!loadNextChunk())
+            {
+                return -1;
+            }
+        }
+
+        int readBytes = Math.min(len, bufferSize - bufferPos);
         System.arraycopy(buf, bufferPos, b, off, readBytes);
         bufferPos += readBytes;
         return readBytes;
@@ -116,43 +150,49 @@ public class JdbcTableInputStream extends InputStream
 
     /**
      * Skips <code>n</code> bytes of input from this input stream.
+     * Transparently advances across chunk boundaries.
      */
-    public synchronized long skip(long n)
+    public synchronized long skip(long n) throws IOException
     {
-        int skipBytes;
-
-        if (bufferPos + n > bufferSize)
-        {
-            skipBytes = bufferSize - bufferPos;
-        }
-        else if (n > Integer.MAX_VALUE)
-        {
-            skipBytes = Integer.MAX_VALUE;
-        }
-        else
-        {
-            skipBytes = (int)n;
-        }
-
-        if (skipBytes < 0)
+        if (n <= 0)
         {
             return 0;
         }
-        bufferPos += skipBytes;
-        return skipBytes;
+
+        long remaining = n;
+        while (remaining > 0)
+        {
+            int inBuffer = bufferSize - bufferPos;
+            if (inBuffer > 0)
+            {
+                long skipNow = Math.min(remaining, inBuffer);
+                bufferPos += (int) skipNow;
+                remaining -= skipNow;
+            }
+            else
+            {
+                if (!loadNextChunk())
+                {
+                    break;
+                }
+            }
+        }
+
+        return n - remaining;
     }
 
     /**
-     * Returns the number of remaining bytes that can be read (or skipped over)
-     * from this input stream.
+     * Returns the total number of bytes that can still be read (or skipped) from this
+     * stream, spanning all remaining chunks.
      */
     public synchronized int available()
     {
-        return bufferSize - bufferPos;
+        long totalRemaining = dataDescription.dataLength - dataDescription.pos - bufferPos;
+        return (int) Math.min(totalRemaining, Integer.MAX_VALUE);
     }
 
     /**
-     * mark/reset is supported.
+     * mark/reset is supported within the current chunk only.
      */
     public boolean markSupported()
     {
@@ -172,7 +212,7 @@ public class JdbcTableInputStream extends InputStream
      */
     public synchronized void reset()
     {
-        bufferPos = (int)mark; // TODO: relative to buffer
+        bufferPos = (int) mark; // TODO: support mark across chunk boundaries
     }
 
     public void close() throws IOException

--- a/vfs2provider-jdbctable/src/main/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStream.java
+++ b/vfs2provider-jdbctable/src/main/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStream.java
@@ -41,13 +41,15 @@ public class JdbcTableInputStream extends InputStream
     }
 
     /** Keep state for re-requesting additional data (position, generation, total length). */
-    final DataDescription dataDescription;
+    private final DataDescription dataDescription;
 
     /** Loads the next chunk from the backing store when the current buffer is exhausted. */
     private final ChunkLoader chunkLoader;
 
     /** position for mark/reset support. */
     long mark = 0;
+    /** absolute start position of the chunk active at {@link #mark(int)} time. */
+    long markChunkPos = 0;
 
     /** read position in the buffer */
     int bufferPos;
@@ -74,9 +76,18 @@ public class JdbcTableInputStream extends InputStream
         }
 
         this.chunkLoader = (pos, maxLen) -> {
+            long previousPos = dataDescription.pos;
             dataDescription.pos = pos;
-            file.nextReadData(dataDescription, maxLen);
-            return dataDescription.buffer;
+            try
+            {
+                file.nextReadData(dataDescription, maxLen);
+                return dataDescription.buffer;
+            }
+            catch (IOException ex)
+            {
+                    dataDescription.pos = previousPos;
+                throw ex;
+            }
         };
     }
 
@@ -89,13 +100,22 @@ public class JdbcTableInputStream extends InputStream
      */
     private boolean loadNextChunk() throws IOException
     {
-        long nextPos = dataDescription.pos + bufferSize;
+        long previousPos = dataDescription.pos;
+        long nextPos = previousPos + bufferSize;
         if (nextPos >= dataDescription.dataLength)
         {
             return false;
         }
         int maxLen = (int) Math.min(MAX_BUFFER_SIZE, dataDescription.dataLength - nextPos);
-        buf = chunkLoader.load(nextPos, maxLen);
+        try
+        {
+            buf = chunkLoader.load(nextPos, maxLen);
+        }
+        catch (IOException ex)
+        {
+            dataDescription.pos = previousPos;
+            throw ex;
+        }
         dataDescription.pos = nextPos;
         bufferPos = 0;
         bufferSize = buf.length;
@@ -205,14 +225,19 @@ public class JdbcTableInputStream extends InputStream
     public synchronized void mark(int readAheadLimit)
     {
         mark = bufferPos;
+        markChunkPos = dataDescription.pos;
     }
 
     /**
      * Resets the buffer to the marked position.
      */
-    public synchronized void reset()
+    public synchronized void reset() throws IOException
     {
-        bufferPos = (int) mark; // TODO: support mark across chunk boundaries
+        if (dataDescription.pos != markChunkPos)
+        {
+            throw new IOException("Marked position is no longer in the current chunk");
+        }
+        bufferPos = (int) mark;
     }
 
     public void close() throws IOException

--- a/vfs2provider-jdbctable/src/test/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStreamTest.java
+++ b/vfs2provider-jdbctable/src/test/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStreamTest.java
@@ -1,0 +1,172 @@
+/*
+ * JdbcTableInputStreamTest.java
+ *
+ * created at 2026-06-18
+ *
+ * Copyright (c) SEEBURGER AG, Germany. All Rights Reserved.
+ */
+package com.seeburger.vfs2.provider.jdbctable;
+
+
+import static org.junit.Assert.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+import java.util.Arrays;
+
+import org.apache.commons.vfs2.FileContent;
+import org.junit.Test;
+import org.mockito.invocation.InvocationOnMock;
+
+import com.seeburger.vfs2.provider.jdbctable.JdbcTableRowFile.DataDescription;
+
+
+/**
+ * Tests for {@link JdbcTableInputStream} covering streams backed by files larger than
+ * {@link JdbcTableInputStream#MAX_BUFFER_SIZE} (50 MB).
+ *
+ * <p>Mockito mocks {@link JdbcTableRowFile} so that the <em>production</em>
+ * {@code protected JdbcTableInputStream(JdbcTableRowFile)} constructor is exercised directly,
+ * with no package-private test seam required in the production class.
+ */
+public class JdbcTableInputStreamTest
+{
+    /**
+     * A stream over a file larger than {@code MAX_BUFFER_SIZE} must deliver all bytes,
+     * not just the first {@code MAX_BUFFER_SIZE} bytes.
+     */
+    @Test
+    public void testReadBulkStopsAtBufferBoundaryForLargeFile() throws Exception
+    {
+        int chunkSize  = 100;           // simulates MAX_BUFFER_SIZE
+        int actualSize = chunkSize + 1; // one byte beyond first chunk
+
+        JdbcTableInputStream stream = buildStream(makeData(actualSize), chunkSize);
+
+        byte[] dest = new byte[actualSize];
+        int totalRead = 0;
+        int n;
+        while ((n = stream.read(dest, totalRead, dest.length - totalRead)) > 0)
+        {
+            totalRead += n;
+        }
+
+        assertEquals("All bytes of a large file must be readable, not just the first buffer-full",
+                     actualSize, totalRead);
+    }
+
+    /**
+     * Single-byte {@code read()} must not stop at the buffer boundary for large files.
+     */
+    @Test
+    public void testReadSingleByteStopsAtBufferBoundaryForLargeFile() throws Exception
+    {
+        int chunkSize  = 10;
+        int actualSize = chunkSize + 1;
+
+        JdbcTableInputStream stream = buildStream(makeData(actualSize), chunkSize);
+
+        int consumed = 0;
+        while (stream.read() != -1)
+        {
+            consumed++;
+        }
+
+        assertEquals("Single-byte read() must deliver all bytes of a large file",
+                     actualSize, consumed);
+    }
+
+    /**
+     * {@code skip(n)} must advance past the first buffer chunk when {@code n} exceeds it.
+     */
+    @Test
+    public void testSkipClipsAtBufferBoundaryForLargeFile() throws Exception
+    {
+        int  chunkSize     = 100;
+        int  actualSize    = chunkSize + 50;
+        long requestedSkip = chunkSize + 25L;
+
+        JdbcTableInputStream stream = buildStream(makeData(actualSize), chunkSize);
+        long actuallySkipped = stream.skip(requestedSkip);
+
+        assertEquals("skip() must be able to advance past the first buffer chunk",
+                     requestedSkip, actuallySkipped);
+    }
+
+    /**
+     * {@code available()} must not drop to zero at the buffer boundary when the file
+     * still has more data.
+     */
+    @Test
+    public void testAvailableIsZeroAfterBufferExhaustedAlthoughFileHasMoreData() throws Exception
+    {
+        int chunkSize  = 64;
+        int actualSize = chunkSize + 1;
+
+        JdbcTableInputStream stream = buildStream(makeData(actualSize), chunkSize);
+
+        byte[] sink = new byte[chunkSize];
+        int read = stream.read(sink, 0, chunkSize);
+        assertEquals(chunkSize, read);
+
+        assertTrue("available() must be > 0 when file has more data beyond the first buffer",
+                   stream.available() > 0);
+    }
+
+    // -----------------------------------------------------------------------
+    // Helpers
+    // -----------------------------------------------------------------------
+
+    /** Builds recognisable test data: bytes cycle 1..127 so values are never zero. */
+    private static byte[] makeData(int size)
+    {
+        byte[] data = new byte[size];
+        for (int i = 0; i < size; i++)
+            data[i] = (byte) (i % 127 + 1);
+        return data;
+    }
+
+    /**
+     * Creates a {@link JdbcTableInputStream} via the <em>real</em> production constructor
+     * by mocking {@link JdbcTableRowFile}.
+     *
+     * <ul>
+     *   <li>{@code getContent().getSize()} returns {@code fullData.length}.</li>
+     *   <li>{@code startReadData(n)} returns a {@link DataDescription} pre-loaded with
+     *       the first {@code chunkSize} bytes.</li>
+     *   <li>{@code nextReadData(desc, n)} fills {@code desc.buffer} with the next slice,
+     *       exactly as the real JDBC implementation does.</li>
+     * </ul>
+     *
+     * @param fullData  complete file content
+     * @param chunkSize maximum bytes per chunk (analogous to MAX_BUFFER_SIZE)
+     */
+    private static JdbcTableInputStream buildStream(byte[] fullData, int chunkSize) throws Exception
+    {
+        FileContent content = mock(FileContent.class);
+        when(content.getSize()).thenReturn((long) fullData.length);
+
+        JdbcTableRowFile file = mock(JdbcTableRowFile.class);
+        when(file.getContent()).thenReturn(content);
+
+        // startReadData: return first chunk eagerly (mirrors real implementation)
+        when(file.startReadData(anyInt())).thenAnswer((InvocationOnMock inv) -> {
+            DataDescription desc = new DataDescription();
+            desc.dataLength = fullData.length;
+            desc.pos        = 0;
+            desc.buffer     = Arrays.copyOf(fullData, chunkSize);
+            return desc;
+        });
+
+        // nextReadData: fill desc.buffer with the next slice in-place (mirrors real implementation)
+        doAnswer((InvocationOnMock inv) -> {
+            DataDescription desc   = inv.getArgument(0);
+            int             maxLen = inv.getArgument(1);
+            int             len    = (int) Math.min(maxLen, fullData.length - desc.pos);
+            desc.buffer = Arrays.copyOfRange(fullData, (int) desc.pos, (int) desc.pos + len);
+            return null;
+        }).when(file).nextReadData(any(DataDescription.class), anyInt());
+
+        return new JdbcTableInputStream(file);
+    }
+}

--- a/vfs2provider-jdbctable/src/test/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStreamTest.java
+++ b/vfs2provider-jdbctable/src/test/java/com/seeburger/vfs2/provider/jdbctable/JdbcTableInputStreamTest.java
@@ -12,6 +12,7 @@ import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.*;
 import static org.mockito.Mockito.*;
 
+import java.io.IOException;
 import java.util.Arrays;
 
 import org.apache.commons.vfs2.FileContent;
@@ -113,6 +114,87 @@ public class JdbcTableInputStreamTest
                    stream.available() > 0);
     }
 
+    /**
+     * After a chunk-load failure the stream must keep its previous position so a subsequent
+     * retry computes the same next chunk and can continue reading.
+     */
+    @Test
+    public void testReadRetriesSameChunkAfterNextReadDataIOException() throws Exception
+    {
+        byte[] fullData = makeData(12);
+        int chunkSize = 4;
+
+        FileContent content = mock(FileContent.class);
+        when(content.getSize()).thenReturn((long) fullData.length);
+
+        JdbcTableRowFile file = mock(JdbcTableRowFile.class);
+        when(file.getContent()).thenReturn(content);
+
+        DataDescription startDesc = new DataDescription();
+        startDesc.dataLength = fullData.length;
+        startDesc.pos = 0;
+        startDesc.buffer = Arrays.copyOf(fullData, chunkSize);
+        when(file.startReadData(anyInt())).thenReturn(startDesc);
+
+        final int[] nextReadCalls = { 0 };
+        doAnswer((InvocationOnMock inv) -> {
+            DataDescription desc = inv.getArgument(0);
+            int maxLen = inv.getArgument(1);
+            nextReadCalls[0]++;
+            if (nextReadCalls[0] == 1)
+            {
+                throw new IOException("simulated DB read failure");
+            }
+            int len = (int) Math.min(Math.min(maxLen, chunkSize), fullData.length - desc.pos);
+            desc.buffer = Arrays.copyOfRange(fullData, (int) desc.pos, (int) desc.pos + len);
+            return null;
+        }).when(file).nextReadData(any(DataDescription.class), anyInt());
+
+        JdbcTableInputStream stream = new JdbcTableInputStream(file);
+
+        byte[] firstChunk = new byte[chunkSize];
+        assertEquals(chunkSize, stream.read(firstChunk, 0, chunkSize));
+
+        try
+        {
+            stream.read();
+            fail("Expected IOException from nextReadData");
+        }
+        catch (IOException expected)
+        {
+            assertEquals("dataDescription.pos must remain at previous chunk after failure",
+                         0L, startDesc.pos);
+        }
+
+        assertEquals("Retry must continue from the same chunk position",
+                     fullData[chunkSize] & 0xff, stream.read());
+        assertEquals("Successful retry must move to the requested chunk start",
+                     (long) chunkSize, startDesc.pos);
+        verify(file, times(2)).nextReadData(any(DataDescription.class), anyInt());
+    }
+
+    @Test
+    public void testResetFailsAfterCrossingChunkBoundary() throws Exception
+    {
+        int chunkSize = 4;
+        JdbcTableInputStream stream = buildStream(makeData(chunkSize + 2), chunkSize);
+
+        stream.mark(0);
+        byte[] firstChunk = new byte[chunkSize];
+        assertEquals(chunkSize, stream.read(firstChunk, 0, firstChunk.length));
+        assertEquals("Cross chunk to make mark invalid", chunkSize + 1, stream.read());
+
+        try
+        {
+            stream.reset();
+            fail("Expected reset to fail after moving to another chunk");
+        }
+        catch (IOException expected)
+        {
+            // expected
+        }
+    }
+
     // -----------------------------------------------------------------------
     // Helpers
     // -----------------------------------------------------------------------
@@ -162,7 +244,7 @@ public class JdbcTableInputStreamTest
         doAnswer((InvocationOnMock inv) -> {
             DataDescription desc   = inv.getArgument(0);
             int             maxLen = inv.getArgument(1);
-            int             len    = (int) Math.min(maxLen, fullData.length - desc.pos);
+            int             len    = (int) Math.min(Math.min(maxLen, chunkSize), fullData.length - desc.pos);
             desc.buffer = Arrays.copyOfRange(fullData, (int) desc.pos, (int) desc.pos + len);
             return null;
         }).when(file).nextReadData(any(DataDescription.class), anyInt());


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved JDBC table streaming for files of any size by loading data in manageable chunks.
  - Reading, skipping, and checking available data now work correctly across chunk boundaries.
  - Streams retry safely after temporary data-loading errors.
  - Mark and reset operations now provide clear errors when resetting after moving beyond the marked chunk.

- **Tests**
  - Added coverage for large-file reads, skipping, availability checks, retry behavior, and mark/reset boundaries.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->